### PR TITLE
Documentation on Plugin Development.

### DIFF
--- a/lib/Log/Any/Plugin.pm
+++ b/lib/Log/Any/Plugin.pm
@@ -88,9 +88,9 @@ what options are supported.
 =back
 
 
-=head1 CONTRIBUTING
+=head1 PLUGIN DEVELOPMENT
 
-=head2 Prerequisites
+=head2 Build Tools
 
 =over
 
@@ -102,9 +102,7 @@ what options are supported.
 =back
 
 
-=head2 Authoring Plugins
-
-=head3 Prerequisites
+=head2 Setup Dependencies
 
 On initial check out of the project, set-up the required dependencies as follows:
 
@@ -125,7 +123,7 @@ requiring explicit installation of L<Module::Build::Version>.
 See the error logs as directed in the C<cpanm> output.
 
 
-=head3 Plugin Development
+=head2 Development
 
 A plugin's entry point is via its C<install> method which has the signature:
 
@@ -141,8 +139,10 @@ define confines of their scope. This module packages in several use-case
 driven plugins that may serve as examples E<mdash> check the
 L<SEE ALSO|"SEE ALSO"> section.
 
-Once a plugin is implemented, and tests added, the full suite of tests can be
-run through a sequence of:
+Once a plugin is implemented, and tests added, re-run the L<Setup Dependencies|"Setup Dependencies">
+steps to get any new required dependencies.
+
+Next, run the full suite of tests through a sequence of:
 
     dzil test
     dzil test --author

--- a/lib/Log/Any/Plugin.pm
+++ b/lib/Log/Any/Plugin.pm
@@ -87,6 +87,73 @@ what options are supported.
 
 =back
 
+
+=head1 CONTRIBUTING
+
+=head2 Prerequisites
+
+=over
+
+=item * You must have [cpanm|App::cpanminus](https://metacpan.org/pod/App::cpanminus) installed.
+
+=item * Then install [Dist::Zilla](http://dzil.org/) via `cpanm Dist::Zilla`. This is
+        a L<Dist::Zilla>-managed project.
+
+=back
+
+
+=head2 Authoring Plugins
+
+=head3 Prerequisites
+
+On initial check out of the project, set-up the required dependencies as follows:
+
+    # Get dependencies
+    dzil authordeps --missing | cpanm
+    dzil listdeps --author | cpanm
+
+Next run a basic test suite:
+
+    dzil test
+
+Install the necessary missed dependencies as needed via C<cpanm> and rerun
+tests till they execute successfully.
+
+For example, there's a L<known issue|https://rt.cpan.org/Public/Bug/Display.html?id=98689>
+requiring explicit installation of L<Module::Build::Version>.
+
+See the error logs as directed in the C<cpanm> output.
+
+
+=head3 Plugin Development
+
+A plugin's entry point is via its C<install> method which has the signature:
+
+    install($class, $adapter_class, %args)
+
+C<$adapter_class> is the L<Log::Any::Adapter> adapter class to be used, e.g.
+C<Stderr>.
+
+C<%args> is a hash of arguments to configure or customise the plugin.
+
+Plugins add new facilities or augment existing facilities, so it's hard to
+define confines of their scope. This module packages in several use-case
+driven plugins that may serve as examples E<mdash> check the
+L<SEE ALSO|"SEE ALSO"> section.
+
+Once a plugin is implemented, and tests added, the full suite of tests can be
+run through a sequence of:
+
+    dzil test
+    dzil test --author
+    dzil test --release
+
+Finally to remove any temporarily generated artifacts, run:
+
+    dzil clean
+
+
+
 =head1 SEE ALSO
 
 L<Log::Any>, L<Log::Any::Plugin::Levels>, L<Log::Any::Plugin::Stringify>


### PR DESCRIPTION
A first attempt. Trickier than I thought to write it in a cohesive way, I focussed mainly on basic devel env set-up (and I'm sure there are missing bits) and plugin basics. 

Because plugins can do a lot, I chose to be DRY and beyond defining `install` as an entry point, I suggested looking at existing examples.

Additionally, I had another one of those "manually install <foo>" type issues -- this was on running test and even `dzil listdeps` and similar:

```
cpanm Pod::Weaver::Section::Contributors

Pod::Weaver::Section::Contributors (for section Contributors) does not appear to be installed


Trace begun at /Users/xdyme/perl5/lib/perl5/Config/MVP/Section.pm line 262
Config::MVP::Section::missing_package('Config::MVP::Section=HASH(0x7fc328289a58)', 'Pod::Weaver::Section::Contributors', 'Contributors') called at /Users/xdyme/perl5/lib/perl5/Config/MVP/Section.pm line 231
Config::MVP::Section::load_package('Config::MVP::Section=HASH(0x7fc328289a58)', 'Pod::Weaver::Section::Contributors', 'Contributors') called at /Users/xdyme/perl5/lib/perl5/Config/MVP/Section.pm line 277
Config::MVP::Section::_BUILD_package_settings('Config::MVP::Section=HASH(0x7fc328289a58)') called at /Users/xdyme/perl5/lib/perl5/Config/MVP/Section.pm line 287
Config::MVP::Section::BUILD('Config::MVP::Section=HASH(0x7fc328289a58)', 'HASH(0x7fc3282760c8)') called at /Users/xdyme/perl5/lib/perl5/darwin-thread-multi-2level/Class/MOP/Method.pm line 128
Class::MOP::Method::execute('Moose::Meta::Method=HASH(0x7fc3250ddd78)', 'Config::MVP::Section=HASH(0x7fc328289a58)', 'HASH(0x7fc3282760c8)') called at /Users/xdyme/perl5/lib/perl5/darwin-thread-multi-2level/Moose/Object.pm line 54
Moose::Object::BUILDALL('Config::MVP::Section=HASH(0x7fc328289a58)', 'HASH(0x7fc3282760c8)') called at /Users/xdyme/perl5/lib/perl5/darwin-thread-multi-2level/Moose/Meta/Class.pm line 279
Moose::Meta::Class::new_object('Moose::Meta::Class=HASH(0x7fc322dbb768)', 'HASH(0x7fc3282760c8)') called at /Users/xdyme/perl5/lib/perl5/darwin-thread-multi-2level/Moose/Object.pm line 24
Moose::Object::new('Config::MVP::Section', 'HASH(0x7fc32756e8e8)') called at /Users/xdyme/perl5/lib/perl5/Config/MVP/Assembler.pm line 144
Config::MVP::Assembler::begin_section('Pod::Weaver::Config::Assembler=HASH(0x7fc32827ea58)', 'Contributors', 'Contributors') called at /Users/xdyme/perl5/lib/perl5/Config/MVP/Assembler.pm line 187
...
```